### PR TITLE
Pin Ubuntu base image to 24.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Use the latest available Ubuntu image as build stage
-FROM ubuntu:latest AS builder
+# Use a pinned Ubuntu LTS image as build stage (kept current by Renovate)
+FROM ubuntu:24.04 AS builder
 
 # Upgrade all packages and install dependencies
 RUN apt-get update \
@@ -41,8 +41,8 @@ RUN case ${TARGETARCH:-amd64} in \
     && /opt/bitcoin/libexec/test_bitcoin --show_progress \
     && rm -v /opt/bitcoin/libexec/test_bitcoin /opt/bitcoin/bin/bitcoin-qt
 
-# Use latest Ubuntu image as base for main image
-FROM ubuntu:latest AS final
+# Use a pinned Ubuntu LTS image as base for main image (kept current by Renovate)
+FROM ubuntu:24.04 AS final
 LABEL author="Kyle Manna <kyle@kylemanna.com>" \
       maintainer="Seth For Privacy <seth@sethforprivacy.com>"
 


### PR DESCRIPTION
## Summary

Pins the Ubuntu base image from the floating `ubuntu:latest` tag to the pinned `ubuntu:24.04` LTS tag in **both** the `builder` and `final` stages of the Dockerfile.

## Why

- **Reproducibility**: `ubuntu:latest` silently moves between releases, which can change toolchain/runtime behaviour without any commit. Pinning to `24.04` makes builds deterministic.
- **Still kept current**: the companion Renovate setup (separate PR) includes the Docker manager, which will open PRs to bump `24.04` when a newer LTS is appropriate (`docker:enableMajor`). Pinning does not mean going stale.

This is a conservative change. The full `test_bitcoin` integrity suite, GPG signature verification, and SHA256SUMS checks are left untouched.

## Local build + run evidence (native arm64, macOS)

```
docker build --platform linux/arm64 -t bitcoind:test .
...
naming to docker.io/library/bitcoind:test done
BUILD_EXIT=0
```

Because download/verify/extract/`test_bitcoin` are a single `&&`-chained `RUN`, a clean exit means GPG verification, checksum validation, and the full unit-test suite all passed.

```
$ docker run --rm bitcoind:test bitcoind --version
Bitcoin Core daemon version v31.0.0 bitcoind
Copyright (C) 2009-2026 The Bitcoin Core developers
```

## CI

`build-image-on-push.yml` triggers on `pull_request` when `Dockerfile` changes, so this PR will be exercised by CI on both the amd64 and arm64 runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
