### PR TITLE
Fix Renovate versioning so Bitcoin Core bumps are proposed (v31.1)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
 # Set variables necessary for download and verification of bitcoind
 ARG TARGETARCH
 ARG ARCH
-# renovate: datasource=github-releases depName=bitcoin/bitcoin extractVersion=^v(?<version>.+)$
+# renovate: datasource=github-releases depName=bitcoin/bitcoin versioning=loose extractVersion=^v(?<version>.+)$
 ARG VERSION=31.0
 ARG BITCOIN_CORE_SIGNATURES="71A3B16735405025D447E8F274810B012346C9A6 \
     152812300785C96444D3334D17565732E08E5E41 \


### PR DESCRIPTION
## Why there was no Renovate PR for v31.1
Renovate **is** running on the repo now (fork processing is enabled; it's been opening Actions PRs). But the Bitcoin Core `VERSION` bump never appeared. The Mend job log shows exactly why:

```
Dependency bitcoin/bitcoin has unsupported/unversioned value 31.0 (versioning=semver)
skipReason: invalid-version
```

The custom manager defaulted that dependency to **`versioning=semver`**, but Bitcoin Core tags (`31.0`, `31.1`) are two-part and **not valid strict semver**, so Renovate detected the dependency and then skipped it.

## Fix
Add `versioning=loose` to the annotation (`loose` handles two-part numeric versions and preserves the bare format on write-back):
```
# renovate: datasource=github-releases depName=bitcoin/bitcoin versioning=loose extractVersion=^v(?<version>.+)$
ARG VERSION=31.0
```

## Verification (`renovate --dry-run`, read-only)
- Current config → `skipReason: invalid-version`, no update (reproduces the bug).
- With this branch's fix → `1 flattened updates found: bitcoin/bitcoin`, **`newValue: "31.1"`** (correct bare two-part value, no `v`, no spurious `.0`).

## After merging
Merge this, then **Run renovate scan** — Renovate will open the `31.0 → 31.1` PR automatically, which will build + run the new CI smoke tests (GPG/SHA verify + version assertion) before anything is tagged `latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)