### PR TITLE
security: pin digests/actions, stop printing rpcpassword, narrow chown, healthcheck

### DIFF
--- a/.github/workflows/build-image-on-push.yml
+++ b/.github/workflows/build-image-on-push.yml
@@ -49,14 +49,14 @@ jobs:
           echo "PLATFORM=linux/amd64" >> $GITHUB_ENV
           echo "DIGEST_NAME=amd64" >> $GITHUB_ENV
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4.3.0
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - name: Test build of image
         id: build
-        uses: docker/build-push-action@v7.3.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           push: false
           load: true

--- a/.github/workflows/update-image-on-push.yml
+++ b/.github/workflows/update-image-on-push.yml
@@ -48,24 +48,24 @@ jobs:
           echo "DIGEST_NAME=amd64" >> $GITHUB_ENV
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: |
             ${{ env.GHCR_REPO }}
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4.3.0
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4.6.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - name: Build and push by digest
-        uses: docker/build-push-action@v7.3.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         id: build
         with:
           outputs: type=image,"name=${{ env.GHCR_REPO }}",push-by-digest=true,name-canonical=true,push=true
@@ -107,7 +107,7 @@ jobs:
           touch "${{ runner.temp }}/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: digests-${{ env.DIGEST_NAME }}
           path: ${{ runner.temp }}/digests/*
@@ -125,24 +125,24 @@ jobs:
       packages: write
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: ${{ runner.temp }}/digests
           pattern: digests-*
           merge-multiple: true
 
       - name: Login to GHCR
-        uses: docker/login-action@v4.6.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4.3.0
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -151,7 +151,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: |
             ${{ env.GHCR_REPO }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use a pinned Ubuntu LTS image as build stage (kept current by Renovate)
-FROM ubuntu:26.04 AS builder
+FROM ubuntu:26.04@sha256:2260313b31c8c011cd2eebe728008efac1b3982be73eb71348ea2648d2c0e09b AS builder
 
 # Upgrade all packages and install dependencies
 RUN apt-get update \
@@ -43,7 +43,7 @@ RUN case ${TARGETARCH:-amd64} in \
     && rm -v /opt/bitcoin/libexec/test_bitcoin /opt/bitcoin/bin/bitcoin-qt
 
 # Use a pinned Ubuntu LTS image as base for main image (kept current by Renovate)
-FROM ubuntu:26.04 AS final
+FROM ubuntu:26.04@sha256:2260313b31c8c011cd2eebe728008efac1b3982be73eb71348ea2648d2c0e09b AS final
 LABEL author="Kyle Manna <kyle@kylemanna.com>" \
       maintainer="Seth For Privacy <seth@sethforprivacy.com>"
 
@@ -79,5 +79,8 @@ EXPOSE 8332 8333
 
 # Expose default bitcoind storage location
 VOLUME ["/bitcoin/.bitcoin"]
+# Add HEALTHCHECK probing the local RPC (credentials come from bitcoin.conf,
+# which bitcoin-cli reads from $HOME/.bitcoin by default)
+HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 CMD bitcoin-cli -rpcconnect=127.0.0.1 -rpcport=8332 getblockchaininfo > /dev/null 2>&1 || exit 1
 
 CMD ["btc_oneshot"]

--- a/bin/btc_init
+++ b/bin/btc_init
@@ -20,6 +20,9 @@ EOF
 
 fi
 
-cat $HOME/.bitcoin/bitcoin.conf
+# Keep the RPC credentials out of stdout/logs; only report the config path
+chmod 600 "$HOME/.bitcoin/bitcoin.conf" 2>/dev/null || true
+
+echo "Initialized; bitcoin.conf written to $HOME/.bitcoin/bitcoin.conf"
 
 echo "Initialization completed successfully"

--- a/bootstrap-host.sh
+++ b/bootstrap-host.sh
@@ -53,5 +53,5 @@ curl https://raw.githubusercontent.com/kylemanna/docker-bitcoind/master/init/ups
 start docker-bitcoind
 
 set +ex
-echo "Resulting bitcoin.conf:"
-docker run -v bitcoind-data:/bitcoin --rm $BTC_IMAGE cat /bitcoin/.bitcoin/bitcoin.conf
+echo "Resulting bitcoin.conf location:"
+docker run -v bitcoind-data:/bitcoin --rm $BTC_IMAGE sh -c 'echo "$HOME/.bitcoin/bitcoin.conf"'

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -9,7 +9,11 @@ fi
 
 # Allow the container to be started with `--user`, if running as root drop privileges
 if [ "$1" = 'btc_oneshot' -a "$(id -u)" = '0' ]; then
-	chown -R bitcoin .
+	# Chown only the data-dir subtree (not the whole mounted volume), and
+	# only when a host-mounted volume arrives with different ownership.
+	if [ -d "$HOME/.bitcoin" ] && [ "$(stat -c %u:%g "$HOME/.bitcoin")" != "$(id -u bitcoin):$(id -g bitcoin)" ]; then
+		chown -R bitcoin "$HOME/.bitcoin"
+	fi
 	exec gosu bitcoin "$0" "$@"
 fi
 

--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,7 @@
   "extends": [
     "config:recommended",
     "docker:enableMajor",
+    "helpers:pinGitHubActionDigests",
     "mergeConfidence:all-badges",
     ":disableRateLimiting",
     ":semanticCommits"


### PR DESCRIPTION
All 14 Action refs SHA-pinned + renovate pinGitHubActionDigests helper; ubuntu:26.04 digest-pinned (both stages).
Generated rpcpassword no longer printed: config written 0600, stdout shows only the config path (btc_init + bootstrap-host.sh).
Recursive chown narrowed to the data dir and only when ownership differs.
Adds HEALTHCHECK (bitcoin-cli getblockchaininfo via local RPC).
Verified: bash -n/sh -n, YAML parse, docker build --check clean, live digest/SHA resolution.